### PR TITLE
Automatically keep the "Current version" up to date via the newest release tag of the DS4Windows repo.

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
 
 <section id="changelog">
 <div class="row section-head">
-<h3>Current version: 2.0.5</h3>
+<h3 name="version">Current version:  loading ...</h3>
 <h3><a href="https://docs.google.com/document/d/1CovpH08fbPSXrC6TmEprzgPwCe0tTjQ_HTFfDotpmxk" target="_new">See full changelog here</a></h3>
 </div>
 </section>
@@ -317,6 +317,15 @@ Donate</h3>
 </section>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script><script>
         window.jQuery || document.write('<script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery-1.10.2.min.js"><\/script>')
-    </script><script type="text/javascript" src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery-migrate-1.2.1.min.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.flexslider.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/waypoints.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.fittext.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.fitvids.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/imagelightbox.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.prettyPhoto.js"></script><script src="https://ryochan7.github.io/ds4windows-site/theme/js/main.js"></script>
+    </script>
+	<script type="text/javascript" src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery-migrate-1.2.1.min.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.flexslider.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/waypoints.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.fittext.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.fitvids.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/imagelightbox.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/jquery.prettyPhoto.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/main.js"></script>
+	<script src="https://ryochan7.github.io/ds4windows-site/theme/js/version.js"></script>
 </body>
 </html>

--- a/theme/js/version.js
+++ b/theme/js/version.js
@@ -1,0 +1,6 @@
+$.getJSON('https://api.github.com/repos/Ryochan7/DS4Windows/releases/latest', function(data) {
+    var version = data.tag_name;
+	version = version.replace('v', '');
+	$(document).ready;
+	$("#changelog > div > h3[name='version']").html("Current version: " + version);
+});

--- a/theme/js/version.js
+++ b/theme/js/version.js
@@ -1,6 +1,5 @@
 $.getJSON('https://api.github.com/repos/Ryochan7/DS4Windows/releases/latest', function(data) {
-    var version = data.tag_name;
+        var version = data.tag_name;
 	version = version.replace('v', '');
-	$(document).ready;
 	$("#changelog > div > h3[name='version']").html("Current version: " + version);
 });


### PR DESCRIPTION
I've added a simple script that will automatically fetch the newest version released on the DS4Windows repo.  
I've linked the .js file with a absolute path just like the other scripts. So to test locally it needs to be changed in line 329 of the index.html accordingly.

I haven't done any extensive testing but in Edge (chromium) and Firefox it's working fine.